### PR TITLE
bugfix: inject-build: storedBuildState handling

### DIFF
--- a/src/InjectBuildCommand.ts
+++ b/src/InjectBuildCommand.ts
@@ -28,6 +28,9 @@ export default class InjectBuildCommand extends Command<CommandContext> {
     );
     const { project } = await Project.find(configuration, this.context.cwd);
 
+    await project.restoreInstallState({
+      restoreResolutions: false,
+    });
     const report = await StreamReport.start(
       { configuration, stdout: this.context.stdout },
       async (report) => {


### PR DESCRIPTION
call restoreInstallState so that state written by previous invocations
to inject-build doesn't get lost

before this fix, all but the last one of the injected isolated builds
would be re-run when building main package