### PR TITLE
libexec/$sourceRoot -> libexec/$name

### DIFF
--- a/src/tmpl/yarn-project.nix.in
+++ b/src/tmpl/yarn-project.nix.in
@@ -140,8 +140,8 @@ let
       mkdir -p $out/libexec $out/bin
 
       # Move the entire project to the output directory.
-      mv $PWD "$out/libexec/$sourceRoot"
-      cd "$out/libexec/$sourceRoot"
+      mv $PWD "$out/libexec/$name"
+      cd "$out/libexec/$name"
 
       # Invoke a plugin internal command to setup binaries.
       yarn nixify install-bin $out/bin


### PR DESCRIPTION
The name of the package's source directory seems like an implementation detail: changing it and nothing else shouldn't change the contents of the package.

Great project by the way, thank you for it!
