### PR TITLE
Fix installPhase when $sourceRoot != $name

### DIFF
--- a/src/tmpl/yarn-project.nix.in
+++ b/src/tmpl/yarn-project.nix.in
@@ -137,7 +137,7 @@ let
     installPhase = ''
       runHook preInstall
 
-      mkdir -p "$out/libexec/$sourceRoot" "$out/bin"
+      mkdir -p "$out/libexec/$name" "$out/bin"
 
       # Move the package contents to the output directory.
       # - If the package.json has a `files` field, only files matching those patterns are copied


### PR DESCRIPTION
I missed a usage of sourceRoot.  I think the tests don't cover the condition of the source directory and package having a different name, which I could have thought of when I was writing the change.  Sorry!!