### PR TITLE
Fix lockfile name

### DIFF
--- a/src/tmpl/yarn-project.nix.in
+++ b/src/tmpl/yarn-project.nix.in
@@ -162,7 +162,8 @@ let
         mkdir -p "$out/libexec/$name"
         tar xzvf package.tgz --directory "$out/libexec/$name" --strip-components=1
 
-        cp .yarnrc* ${lockfile} "$out/libexec/$name"
+        cp .yarnrc* "$out/libexec/$name"
+        cp ${lockfile} "$out/libexec/$name/yarn.lock"
         cp --recursive .yarn "$out/libexec/$name"
 
         # If the project uses the node-modules linker, then


### PR DESCRIPTION
Currently the packages will contain lock files with valid contents but their names include their nix hash.  This makes using the `yarn` attribute annoying.

With this change, the lock files will be named `yarn.lock`.