### PR TITLE
Fix missing PnP linkers if node_modules exists

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -325,6 +325,8 @@ export default async (
       ISOLATED: isolatedCode.join("\n"),
       ISOLATED_INTEGRATION: indent("      ", isolatedIntegration.join("\n")),
       NEED_ISOLATED_BUILD_SUPPRORT: isolatedIntegration.length > 0,
+      USES_PNP_LINKER: configuration.get("nodeLinker") === "pnp",
+      USES_NM_LINKER: configuration.get("nodeLinker") === "node-modules",
     });
     await xfs.writeFilePromise(nixExprPath, projectExpr);
 

--- a/src/tmpl/yarn-project.nix.in
+++ b/src/tmpl/yarn-project.nix.in
@@ -174,14 +174,13 @@ let
         cp ${lockfile} "$out/libexec/$name/yarn.lock"
         cp --recursive .yarn "$out/libexec/$name"
 
-        # If the project uses the node-modules linker, then
-        # include the node_modules folder in the package.
-        if [ -d node_modules ]; then
-          cp --recursive node_modules "$out/libexec/$name"
-        else
-          # Otherwise, assume PnP. Copy the loader into the package.
-          cp .pnp.* "$out/libexec/$name"
-        fi
+        # Copy the Yarn linker output into the package.
+#@@ IF USES_PNP_LINKER
+        cp .pnp.* "$out/libexec/$name"
+#@@ ENDIF USES_PNP_LINKER
+#@@ IF USES_NM_LINKER
+        cp --recursive node_modules "$out/libexec/$name"
+#@@ ENDIF USES_NM_LINKER
       fi
 
       cd "$out/libexec/$name"
@@ -190,10 +189,10 @@ let
       mkdir -p "$out/bin"
       yarn nixify install-bin $out/bin
 
+#@@ IF USES_NM_LINKER
       # A package with node_modules doesn't need the cache
-      if [ -d node_modules ]; then
-        yarn cache clean
-      fi
+      yarn cache clean
+#@@ ENDIF USES_NM_LINKER
 
       runHook postInstall
     '';


### PR DESCRIPTION
This can happen because some tools write to `node_modules/.cache` as a convention.