### PR TITLE
src/generate.ts: Create the nixExprPath directory if it doesn't exist

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -395,6 +395,7 @@ export default async (
       USES_PNP_LINKER: configuration.get("nodeLinker") === "pnp",
       USES_NM_LINKER: configuration.get("nodeLinker") === "node-modules",
     }).replace(/\n\n\n+/g, "\n\n");
+    await xfs.mkdirpPromise(ppath.dirname(nixExprPath));
     await xfs.writeFilePromise(nixExprPath, projectExpr);
 
     // Create a wrapper if it does not exist yet.


### PR DESCRIPTION
This can happen in a multi-project workspace, where only some projects use Nix; in this case, the directory with Nix-related files may not exist in some build environments.